### PR TITLE
connector-rst-doc

### DIFF
--- a/presto-docs/src/main/sphinx/develop/connectors.rst
+++ b/presto-docs/src/main/sphinx/develop/connectors.rst
@@ -81,3 +81,12 @@ Given a split and a list of columns, the record set provider is
 responsible for delivering data to the Presto execution engine.
 It creates a ``RecordSet``, which in turn creates a ``RecordCursor``
 that is used by Presto to read the column values for each row.
+
+Files with @JsonCreator annotation
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If any of your files have @JsonCreator annotation,
+make sure that the fields marked with @JsonProperty should also
+have a corresponding getter annotated with @JsonProperty annotation.
+Otherwise, the fields, without the getter, will have a null value during
+deserialization process.


### PR DESCRIPTION
## Description
Modified https://github.com/prestodb/presto/blob/54a7ec79a344a4766e8fcf06e7ff4d10b7f2c380/presto-docs/src/main/sphinx/develop/connectors.rst
Added requirement about files that have a @JsonCreator annotation

## Motivation and Context
During development of a custom connector, there was a need to write cusotm split classes. These classes uses a @JsonCreator annotation in their constructor. If we were to add some extra fields in the class, and do not create their getters annotated with @JsonProperty annotation then the objects get null values during deserialization.

## Impact
The need for this information may save developers lot of hours

## Test Plan
<!---Please fill in how you tested your change-->

## Contributor checklist

- [ ] Please make sure your submission complies with our [development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), [commit message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests), and [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution).
- [ ] PR description addresses the issue accurately and concisely.  If the change is non-trivial, a GitHub Issue is referenced.
- [ ] Documented new properties (with its default value), SQL syntax, functions, or other functionality.
- [ ] If release notes are required, they follow the [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines).
- [ ] Adequate tests were added if applicable.
- [ ] CI passed.

## Release Notes
Please follow [release notes guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) and fill in the release notes below.

```
== RELEASE NOTES ==

General Changes
* ...
*Changes in the connectors.rst files

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```

